### PR TITLE
Modified the distance threshold

### DIFF
--- a/src/locate_barcode.cpp
+++ b/src/locate_barcode.cpp
@@ -14,7 +14,7 @@
 #include<cmath>
 
 #define PI 3.14159265
-#define THRESHOLD 1.8
+#define THRESHOLD 3
 
 using std::placeholders::_1;
 using namespace std;


### PR DESCRIPTION
The far away points dropping behavior is weird. Since the mapping function is very accurate, modify the distance threshold  to a larger value for now.